### PR TITLE
feat(scraper): add pause and continue scraping controls

### DIFF
--- a/background.js
+++ b/background.js
@@ -16,13 +16,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         });
       }
     });
+  } else if (message.type === 'CONTINUE_SCRAPING') {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (tabs[0]) {
+        chrome.tabs.sendMessage(tabs[0].id, { type: 'CONTINUE_SCRAPING' });
+      }
+    });
   } else if (message.type === 'STOP_SCRAPING') {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       if (tabs[0]) {
         chrome.tabs.sendMessage(tabs[0].id, { type: 'STOP_SCRAPING' });
       }
     });
-  } else if (message.type === 'NEW_DATA' || message.type === 'SCRAPING_STATUS' || message.type === 'SCRAPING_COMPLETE') {
+  } else if (message.type === 'NEW_DATA' || message.type === 'SCRAPING_STATUS' || message.type === 'SCRAPING_COMPLETE' || message.type === 'SCRAPING_PAUSED' || message.type === 'SCROLL_PROGRESS') {
     chrome.runtime.sendMessage(message);
   }
   return true;

--- a/sidepanel.html
+++ b/sidepanel.html
@@ -67,6 +67,10 @@
                 <span class="icon">▶</span>
                 Bắt đầu thu thập
             </button>
+            <button id="continueScraping" class="btn btn-success" disabled style="display: none;">
+                <span class="icon">⏩</span>
+                Tiếp tục
+            </button>
             <button id="stopScraping" class="btn btn-secondary" disabled>
                 <span class="icon">⏹</span>
                 Dừng
@@ -80,6 +84,7 @@
         <div class="progress-section" id="progressSection" style="display: none;">
             <div class="progress-info">
                 <span>Đã thu thập: <strong id="recordCount">0</strong> bản ghi</span>
+                <span>Scroll: <strong id="scrollCount">0</strong> lần</span>
                 <span>Trùng lặp: <strong id="duplicateCount">0</strong></span>
             </div>
             <div class="progress-bar">

--- a/styles.css
+++ b/styles.css
@@ -241,19 +241,21 @@ body {
 .controls-section {
     display: flex;
     justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 20px
+    gap: 8px;
+    margin-bottom: 20px;
+    flex-wrap: wrap
 }
 
 .controls-section .btn {
-    flex: 1
+    flex: 1;
+    min-width: 120px
 }
 
 .btn {
     display: flex;
     align-items: center;
     gap: 8px;
-    padding: 12px 20px;
+    padding: 12px 16px;
     border: none;
     border-radius: 8px;
     font-size: 14px;
@@ -261,8 +263,7 @@ body {
     cursor: pointer;
     transition: all 0.2s ease;
     text-decoration: none;
-    justify-content: center;
-    min-width: 120px
+    justify-content: center
 }
 
 .btn:disabled {
@@ -277,6 +278,16 @@ body {
 
 .btn-primary:hover:not(:disabled) {
     background: #2563eb;
+    transform: translateY(-1px)
+}
+
+.btn-success {
+    background: #10b981;
+    color: white
+}
+
+.btn-success:hover:not(:disabled) {
+    background: #059669;
     transform: translateY(-1px)
 }
 
@@ -340,7 +351,9 @@ body {
     justify-content: space-between;
     align-items: center;
     margin-bottom: 12px;
-    font-size: 14px
+    font-size: 14px;
+    flex-wrap: wrap;
+    gap: 8px
 }
 
 .progress-info strong {
@@ -440,6 +453,11 @@ body {
     animation: spin 1s linear infinite
 }
 
+.status-paused .status-dot {
+    background: #8b5cf6;
+    animation: pulse 2s infinite
+}
+
 .status-success .status-dot {
     background: #22c55e
 }
@@ -458,7 +476,7 @@ body {
     }
 }
 
-@media (max-width:480px) {
+@media (max-width:640px) {
     .container {
         padding: 12px
     }
@@ -467,7 +485,7 @@ body {
         flex-direction: column
     }
 
-    .btn {
+    .controls-section .btn {
         min-width: 100%
     }
 
@@ -481,13 +499,10 @@ body {
         flex-direction: column
     }
 
-    .column-row {
-        flex-direction: column
-    }
-
     .progress-info {
         flex-direction: column;
         gap: 4px;
-        text-align: center
+        text-align: center;
+        align-items: center
     }
 }


### PR DESCRIPTION
Add a "Continue" button to resume scraping after a pause, improving user
control over the scraping process. Track and display the number of scrolls
during scraping to provide better progress insight. Update styles for better
button layout and responsiveness. Reset scroll count when starting or
clearing scraping data to maintain accurate metrics.